### PR TITLE
Add Q pointer offsets, closing issue #3

### DIFF
--- a/cell.hpp
+++ b/cell.hpp
@@ -38,6 +38,7 @@ enum class KeyTag {
     KeyKey,             // 0000_0011 <- Key key
     ProcedureKey,       // 0000_1011 <- Procedure key
     BooleanKey,         // 0001_0011 <- Boolean key
+    IntVectorKey,       // 0001_1011 <- Int vector key
 };
 
 const static uint64_t FALSE_VALUE = (((int)UpperTag::False) << TAG_WIDTH) | (int)Tag::Special;

--- a/cell.hpp
+++ b/cell.hpp
@@ -92,14 +92,14 @@ public:
     }
 
     inline bool isProcedure() const {
-        return isPtr() && (deref()->u64 == ProcedureTag);
+        return isTaggedPtr() && (deref()->u64 == ProcedureTag);
     }
 
 public:
     inline bool isSmall() const { return getTag() == Tag::Small; }
     inline bool isFalse() const { return ( u64 & 0xF ) == ( FALSE_VALUE & 0xF ); }
     inline bool isntFalse() const { return ( u64 & 0xF ) != ( FALSE_VALUE & 0xF ); }
-    inline bool isPtr() const { return (u64 & TAG_MASK) == (int)Tag::TaggedPtr; }
+    inline bool isTaggedPtr() const { return (u64 & TAG_MASK) == (int)Tag::TaggedPtr; }
 };
 
 class Ident {

--- a/cell.hpp
+++ b/cell.hpp
@@ -97,6 +97,9 @@ public:
 
 public:
     inline bool isSmall() const { return getTag() == Tag::Small; }
+    inline int getSmall() const { return i64 >> TAG_WIDTH; }
+
+public:
     inline bool isFalse() const { return ( u64 & 0xF ) == ( FALSE_VALUE & 0xF ); }
     inline bool isntFalse() const { return ( u64 & 0xF ) != ( FALSE_VALUE & 0xF ); }
     inline bool isTaggedPtr() const { return (u64 & TAG_MASK) == (int)Tag::TaggedPtr; }

--- a/codeplanter.cpp
+++ b/codeplanter.cpp
@@ -90,6 +90,11 @@ void CodePlanter::addData(Cell cell) {
     _builder.addCell(cell);
 }
 
+void CodePlanter::addDataQ(Cell cell) {
+    _q_offsets.push_back(_builder.size());
+    _builder.addCell(cell);
+}
+
 void CodePlanter::addRawUInt(uint64_t n) {
     _builder.addCell( Cell{ .u64 = n } );
 }
@@ -230,7 +235,7 @@ void CodePlanter::POP( const std::string & name ) {
 
 void CodePlanter::PUSHQ(int64_t i) {
     addInstruction(Instruction::PUSHQ);
-    addData(Cell::makeSmall(i));
+    addDataQ(Cell::makeSmall(i));
 }
 
 void CodePlanter::ADD() {

--- a/codeplanter.hpp
+++ b/codeplanter.hpp
@@ -42,6 +42,7 @@ private:
     Builder _builder;
     size_t _before_instructions;
     PlaceHolder _length;
+    PlaceHolder _qblock;
     PlaceHolder _num_locals;
 
     //  Locals

--- a/codeplanter.hpp
+++ b/codeplanter.hpp
@@ -50,6 +50,9 @@ private:
     size_t max_level = 0;
     std::vector<PlaceHolder> local_fixups;
 
+    // Pointer offsets
+    std::vector<int>  _q_offsets;
+
     // We allocate as many extra roots as we need during code-planting and
     // dispose of them all at the end of the code-planting process.
     std::vector<XRoot> _xroots;
@@ -64,6 +67,7 @@ public:
     void addInstruction(Instruction inst);
 
     void addData(Cell cell);
+    void addDataQ(Cell cell);
 
     void addRawUInt(uint64_t n);
 

--- a/engine.cpp
+++ b/engine.cpp
@@ -327,6 +327,28 @@ void Engine::run(const std::string & main) {
     }
 }
 
+void Engine::multiLineDisplay(Cell p) {
+    if (p.isSmall()) {
+        std::cout << "  Value : " << p.getSmall() << std::endl;
+    } else if (p.isProcedure()) {
+        Cell * pk = p.deref();
+        std::cout << "  Procedure" << std::endl;
+        std::cout << "    NumLocals: " << (pk + ProcedureLayout::NumLocalsOffset)->u64 << std::endl;
+        int pl = (pk + ProcedureLayout::LengthOffset)->getSmall();
+        std::cout << "    Length   : " << pl << std::endl;
+        int qb = (pk + ProcedureLayout::QBlockOffset)->getSmall();
+        std::cout << "    QBlock   : " << qb << std::endl;
+        for (int i = qb; i < pl; i++) {
+            int offset = (pk + i)->i64;
+            std::cout << "      offset[" << i - qb << "]: " << offset << " -> ";
+            Cell q = pk[offset];
+            std::cout << q.u64 << std::endl;
+        }
+    } else {
+        std::cout << p.u64 << std::endl;
+    }
+}
+
 void Engine::debugDisplay() {
     std::cout << "Value Stack (Bottom to Top)" << std::endl;
     for ( auto & c : _valueStack ) {
@@ -335,7 +357,8 @@ void Engine::debugDisplay() {
     std::cout << std::endl;
     std::cout << "Dictionary" << std::endl;
     for (auto & [name, ident] : _symbolTable) {
-        std::cout << name << " = " << ident->value().u64 << std::endl;
+        std::cout << name << ":" << std::endl;
+        multiLineDisplay(ident->value());
     }
 }
 

--- a/engine.hpp
+++ b/engine.hpp
@@ -78,6 +78,8 @@ public:
 
 public:
     void debugDisplay();
+private:
+    void multiLineDisplay(Cell p);
 };
 
 } // namespace poppy

--- a/layout.hpp
+++ b/layout.hpp
@@ -3,9 +3,10 @@
 
 class ProcedureLayout {
 public:
-    static const unsigned int HeaderSize = 5;
+    static const unsigned int HeaderSize = 4;
     static const int QBlockOffset = -2;
     static const int LengthOffset = -1;
+    static const int KeyOffsetFromStart = 2;
     static const int NumLocalsOffset = 1;
     static const int InstructionsOffset = 2;
 };

--- a/layout.hpp
+++ b/layout.hpp
@@ -3,11 +3,11 @@
 
 class ProcedureLayout {
 public:
-    static const unsigned int HeaderSize = 4;
+    static const unsigned int HeaderSize = 5;
+    static const int QBlockOffset = -2;
     static const int LengthOffset = -1;
-    static const int GCPointersOffset = 1;
-    static const int NumLocalsOffset = 2;
-    static const int InstructionsOffset = 3;
+    static const int NumLocalsOffset = 1;
+    static const int InstructionsOffset = 2;
 };
 
 #endif

--- a/poppy.cpp
+++ b/poppy.cpp
@@ -68,10 +68,10 @@ int main(int argc, char **argv) {
         main.LABEL(target);
         main.RETURN();
         
-        main.debugDisplay();
-
+        
         main.global( "main" );
         main.buildAndBind( "main" );
+        main.debugDisplay();
 
         engine.run( "main" );
 


### PR DESCRIPTION
PUSHQ and CALLQ embed pointers into the Procedure record. We record the offset of their position from the Key and add those raw values to the end of the record, following the last instruction (which will always be some kind of exit e.g. return, throw, stop).